### PR TITLE
Clean `loadonly` & `transient` fields on `clean()` method

### DIFF
--- a/bson-model-generator/src/main/resources/v2_java_code_generator.rb
+++ b/bson-model-generator/src/main/resources/v2_java_code_generator.rb
@@ -347,7 +347,7 @@ class ModelConf
   def generate_clean_code
     code = "    @Override\n"
     code << "    public #@name clean() {\n"
-    fields = reality_fields
+    fields = @fields.select { |field| not field.virtual? }
     unless fields.empty?
       fields.map do |field|
         field.generate_clean_code
@@ -356,8 +356,8 @@ class ModelConf
       end.each do |c|
         code << c
       end
+      code << "        resetStates();\n"
     end
-    code << "        resetStates();\n"
     code << "        return this;\n"
     code << "    }\n\n"
   end


### PR DESCRIPTION
Fix #7 